### PR TITLE
esapi: fix Specifying types in document update requests is deprecated problem

### DIFF
--- a/esapi/api.update.go
+++ b/esapi/api.update.go
@@ -86,10 +86,6 @@ func (r UpdateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 
 	method = "POST"
 
-	if r.DocumentType == "" {
-		r.DocumentType = "_doc"
-	}
-
 	path.Grow(1 + len(r.Index) + 1 + len(r.DocumentType) + 1 + len(r.DocumentID) + 1 + len("_update"))
 	path.WriteString("/")
 	path.WriteString(r.Index)


### PR DESCRIPTION
fix Specifying types in document update requests is deprecated problem
https://www.elastic.co/guide/en/elasticsearch/reference/7.15/removal-of-types.html
